### PR TITLE
Fix grep errors

### DIFF
--- a/relocate.sh
+++ b/relocate.sh
@@ -73,17 +73,17 @@ tee <<-EOF
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 EOF
     cd /bin
-    find . -type f | xargs grep -l "$old" |tee /dev/tty | xargs sed -i "s+${old}+${new}+g"
+    find . -type f -print0 | xargs -0 grep -l -r "$old" |tee /dev/tty | xargs sed -i "s+${old}+${new}+g"
     echo
     read -p '✅ | /bin Files Updated | Press [ENTER] to Continue ' typed </dev/tty
     sleep 0.5
     cd /var/plexguide
-    find . -type f | xargs grep -l "$old" |tee /dev/tty | xargs sed -i "s+${old}+${new}+g"
+    find . -type f -print0 | xargs -0 grep -l -r "$old" |tee /dev/tty | xargs sed -i "s+${old}+${new}+g"
     echo
     read -p '✅ | /var/plexguide Files Updated | Press [ENTER] to Continue ' typed </dev/tty
     sleep 0.5
     cd /opt
-    find . -type f | xargs grep -l "$old" |tee /dev/tty | xargs sed -i "s+${old}+${new}+g"
+    find . -type f -print0 | xargs -0 grep -l -r "$old" |tee /dev/tty | xargs sed -i "s+${old}+${new}+g"
     echo
     read -p '✅ | /opt Files Updated | Press [ENTER] to Continue ' typed </dev/tty
 }


### PR DESCRIPTION
grep was unable to handle files/directories with spaces in their names the way that I wrote it. This change fixes that.

This only affected grep (logging to console). Previous runs of this script would have still worked as the stream engine was not affected by this. Users do not need to re-run this script after this change!!